### PR TITLE
Add pageContext on creation

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -45,7 +45,8 @@ exports.createPages = ({ actions, reporter }, { routeFilePath }) => {
     reporter.info(`Creating route: ${route.path}`)
     createPage({
       path: route.path,
-      component: path.resolve(route.component)
+      component: path.resolve(route.component),
+      context: route.context ? route.context : {},
     })
   })
   activity.end()


### PR DESCRIPTION
This improvement is so that we can pass the context when we create the pages. Now it is possible to pass the context inside the route object. 

This is a feature designed in the scenario where we use the same page with different routes, for example:

```js
module.exports = {
    app1: {
      path: `/app1`,
      component: `src/pages/App/index.js`,
      context: {
        page: "App1"
      }
    },
   app2: {
      path: `/app2`,
      component: `src/pages/App/index.js`,
      context: {
        page: "App2"
      }
    }
}
```


